### PR TITLE
Automate the Docker build to ghcr. Fix Dockerfile

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,36 @@
+name: Build and Push to GHCR
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM python:slim-bookworm
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     git \
+    gcc \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 # Prefer environment variable over `bot_token.txt` (true/false)
-preferenvforbottoken = False
+preferenvforbottoken = True
 
 [GeneralSettings]
 # Restart on connection failure


### PR DESCRIPTION
This pull request includes changes to automate the Docker build and push process and to update the Dockerfile to include an additional dependency.

Automation of Docker build and push process:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R1-R36): Added a GitHub Actions workflow to build and push Docker images to GitHub Container Registry (GHCR) on push and pull request events to the main branch.

Update to Dockerfile dependencies:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R7): Added `gcc` to the list of installed packages to ensure necessary build tools are available.