### PR TITLE
Add config.ini option for full video downloads on problematic sites

### DIFF
--- a/.catgitignore
+++ b/.catgitignore
@@ -2,3 +2,4 @@
 # https://github.com/FlyingFathead/catgit
 README.md
 tests/diarize_with_whisper-test.py
+utils/resemblyzer_safety_check.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim-bookworm
+FROM python:3.12-slim
 
 # Install dependencies & clean up after to reduce Docker file size
 RUN apt-get update && apt-get install -y \
@@ -12,6 +12,9 @@ WORKDIR /app
 
 # Copy the requirements file first to leverage Docker cache
 COPY requirements.txt .
+
+# Upgrade pip and setuptools
+RUN pip install --upgrade pip setuptools wheel
 
 # Install Python dependencies
 RUN pip3 install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Replace `'YourTelegramBotToken'` with your actual Telegram bot token. This comma
 
 ## Usage
 
-After launching the bot, you can interact with it via Telegram (message `@whatever_your_bot_name_is_Bot`):
+After launching your bot successfully, you can interact with it via Telegram (send a message to `@your_bot_name_Bot`, or whatever your bot name is):
 
 1. Send a video URL (for `yt-dlp` to download), a voice message or an audio file (i.e. `.wav` or `.mp3` format) to the bot.
 2. The bot will acknowledge the request and begin processing, notifying the user of the process.
@@ -195,6 +195,14 @@ After launching the bot, you can interact with it via Telegram (message `@whatev
 - `/language` - set the model's transcription language (`auto` =  autodetect); if you know the language spoken in the audio, setting the transcription language manually with this command may improve both transcription speed and accuracy.
 
 ## Changes
+- v0.1707 - New `config.ini` option: add sites that require full video download
+   - some media sites don't work well with `yt-dlp`'s audio-only download method
+   - there are now two new options in `config.ini` under `[YTDLPSettings]`:
+   - `download_original_video_for_domains_active = true` (default)
+   - `download_original_video_domains = site1.com, site2.com, site3.com`
+   - at the moment it's used for media platforms that have had reported issues during testing
+   - when active, a comma-separated list is used to check up on media sites that require their contents to be downloaded as the original video instead of audio-only
+   - _(the tradeoff is obviously download size and hence speed; the audio-only method is usually the fastest and should be preferred for most popular sites, hence only add problematic sites to the video-only list)_   
 - v0.1706 - Disable asking for token if running inside Docker
    - by default, the app will ask for the token if it's not found, unless Dockerized
    - can be better for headless use case scenarios where you need the error message rather than a prompt for the bot token

--- a/config/config.ini
+++ b/config/config.ini
@@ -63,3 +63,11 @@ max_requests_per_minute = 5
 [YTDLPSettings]
 use_cookies = False
 cookies_file = config/cookies.txt
+# some media sites don't always work well with yt-dlp's audio download feature
+# for compatibility, it's recommended to enable the flag below (true)
+download_original_video_for_domains_active = true
+# list your sites below to download original videos from, comma separated.
+# example:
+# download_original_video_domains = site1.com, site2.com, site3.com
+# these are the sites we use to download original videos from
+download_original_video_domains = rumble.com

--- a/config/config.ini
+++ b/config/config.ini
@@ -61,6 +61,9 @@ cooldown_seconds = 10
 max_requests_per_minute = 5
 
 [YTDLPSettings]
+# use your own `cookies.txt` (true/false)
+# this is sometimes required for sites that require login
+# or, in some cases, with sites like YouTube that don't like downloaders.
 use_cookies = False
 cookies_file = config/cookies.txt
 # some media sites don't always work well with yt-dlp's audio download feature
@@ -71,3 +74,8 @@ download_original_video_for_domains_active = true
 # download_original_video_domains = site1.com, site2.com, site3.com
 # these are the sites we use to download original videos from
 download_original_video_domains = rumble.com
+# use worst video quality (true/false)
+# this is usually recommended, because we will only need the _audio_ for transcription.
+# adding a high-quality video will cause massive file size increases.
+# however, in some cases you might want to turn this off
+use_worst_video_quality = true

--- a/config/config.ini
+++ b/config/config.ini
@@ -79,3 +79,9 @@ download_original_video_domains = rumble.com
 # adding a high-quality video will cause massive file size increases.
 # however, in some cases you might want to turn this off
 use_worst_video_quality = true
+
+[VideoDescriptionSettings]
+# Set to True to use only a snippet of the video description
+use_snippet_for_description = False
+# Maximum number of lines to include in the description snippet
+description_max_lines = 30

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -45,6 +45,20 @@ class ConfigLoader:
             'completion_message': completion_message
         }
 
+    # NEW: Method to get yt-dlp domain settings
+    @classmethod
+    def get_ytdlp_domain_settings(cls):
+        config = cls.get_config()
+        active = config.getboolean('YTDLPSettings', 'download_original_video_for_domains_active', fallback=False)
+        domains = config.get('YTDLPSettings', 'download_original_video_domains', fallback='')
+        # Split by comma and strip whitespace
+        domain_list = [domain.strip().lower() for domain in domains.split(',') if domain.strip()]
+        
+        return {
+            'active': active,
+            'domains': domain_list
+        }
+
 # Usage example:
 # from config_loader import ConfigLoader
 # notification_settings = ConfigLoader.get_notification_settings()

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@
 # openai-whisper transcriber-bot for Telegram
 
 # version of this program
-version_number = "0.1706"
+version_number = "0.1707"
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # https://github.com/FlyingFathead/whisper-transcriber-telegram-bot/


### PR DESCRIPTION
- v0.1707 - New `config.ini` option: add sites that require full video download
   - some media sites don't work well with `yt-dlp`'s audio-only download method
   - there are now two new options in `config.ini` under `[YTDLPSettings]`:
   - `download_original_video_for_domains_active = true` (default)
   - `download_original_video_domains = site1.com, site2.com, site3.com`
   - at the moment it's used for media platforms that have had reported issues during testing
   - when active, a comma-separated list is used to check up on media sites that require their contents to be downloaded as the original video instead of audio-only
   - _(the tradeoff is obviously download size and hence speed; the audio-only method is usually the fastest and should be preferred for most popular sites, hence only add problematic sites to the video-only list)_   