### PR TITLE
`v0.1713` - custom yt-dlp commands in `config.ini`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ If you just need to see the options and help, type:
 ```
 
 ## Changes
+- v0.1713 - Added customizable `yt-dlp` commands to `config.ini` under `custom_yt_dlp_args`
+   - Leave the entry blank if you don't want any custom commands to be added.
+   - Adding custom commands might help with some sites that have i.e. chunking problems during download, etc.
 - v0.1712 - More configuration options for user notifications
    - Added two new booleans in `config.ini` under `[NotificationSettings]`:
      - `send_video_info` (default: `true`): Whether the bot should send video metadata (title, duration, channel info, etc.) to the user in Telegram. If `false`, the info is still logged to console, but not sent to the user.

--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ If you just need to see the options and help, type:
 ## Changes
 - v0.1713 - Added customizable `yt-dlp` commands to `config.ini` under `custom_yt_dlp_args`
    - Leave the entry blank if you don't want any custom commands to be added.
-   - Adding custom commands might help with some sites that have i.e. chunking problems during download, etc.
-- v0.1712 - More configuration options for user notifications
+   - Adding custom commands might help with some sites that have i.e. chunking problems during download, or if you need to tweak something, etc.
+- v0.1712 - More configuration options for user notifications.
    - Added two new booleans in `config.ini` under `[NotificationSettings]`:
      - `send_video_info` (default: `true`): Whether the bot should send video metadata (title, duration, channel info, etc.) to the user in Telegram. If `false`, the info is still logged to console, but not sent to the user.
      - `send_detailed_info` (default: `true`): Whether the bot should send a detailed “transcription process info” message (model name, language, estimated time, etc.) to the user in Telegram. Even if disabled, the console/logger still records the detailed info.

--- a/config/config.ini
+++ b/config/config.ini
@@ -101,7 +101,15 @@ cooldown_seconds = 10
 max_requests_per_minute = 5
 
 [YTDLPSettings]
-# use your own `cookies.txt` file (true/false)
+# (((=== Custom commands for yt-dlp when downloading video/audio ===)))
+# If the entry below is blank, no extra flags are appended to the yt-dlp command.
+# (leave blank like so if no extra commands aren't needed)
+# (Example below); can help with "chunk side exceeded" errors in some cases, i.e.:
+# custom_yt_dlp_args = --http-chunk-size 0
+# Just leave the entry below blank if you have no idea what you're doing. :-)
+custom_yt_dlp_args = 
+# (((=== Cookies ===)))
+# Use your own `cookies.txt` file (true/false)
 # this is sometimes required for sites that require login
 # or, in some cases, with sites like YouTube that don't like downloaders.
 # (will be skipped if the file isn't found)
@@ -114,22 +122,23 @@ browser_type = firefox
 # your browser cookies profile location, leave blank to use default location
 # (can be set either as a /path/to/profile.default or env var to read the location from)
 browser_cookies_profile = $TRANSCRIBERBOT_BROWSER_COOKIE_LOCATION
-# options for cache control
+# (((=== Cache Control ===)))
 # Use no cache dir (true/false); might work better in some use scenarios
 no_cache_dir = True
 # cache dir location, leave empty for default
 custom_cache_dir = 
+# (((=== Video-only Sites ===)))
 # some media sites don't always work well with yt-dlp's audio download feature
 # for compatibility, it's recommended to enable the flag below (true)
 download_original_video_for_domains_active = true
 # list your sites below to download original videos from, comma separated.
-# example:
+# Example:
 # download_original_video_domains = site1.com, site2.com, site3.com
-# these are the sites we use to download original videos from
+# In other words, these are the sites we use to download original videos from.
 # (i.e. rumble.com has been a site that's been widely reported as having broken downloads; 
 # hence the video-only download method for that site and others alike.)
 download_original_video_domains = rumble.com
-# use worst video quality (true/false)
+# Use worst video quality when having to download videos (true/false)
 # this is usually recommended, because we will only need the _audio_ for transcription.
 # adding a high-quality video will cause massive file size increases.
 # however, in some cases you might want to turn this off

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -10,6 +10,7 @@ import sys
 import time
 import logging
 import re
+import shlex
 import threading
 import asyncio
 from asyncio.exceptions import TimeoutError
@@ -178,6 +179,7 @@ def split_message(message, max_length=3500):
 async def download_audio(url, audio_path):
     config = ConfigLoader.get_config()
     ytdlp_settings = ConfigLoader.get_ytdlp_domain_settings()
+    extra_args_str = config.get('YTDLPSettings', 'custom_yt_dlp_args', fallback='').strip()
 
     # --- Added verbose logging for cookie usage ---
     use_cookies_file = config.getboolean('YTDLPSettings', 'use_cookies_file', fallback=False)
@@ -253,6 +255,15 @@ async def download_audio(url, audio_path):
             "--dump-json",
             url
         ]
+
+        # If there are custom args, parse them into a list and extend the command
+        if extra_args_str:
+            extra_args_list = shlex.split(extra_args_str)
+            logger.info(f"Using custom yt-dlp arguments from config: {extra_args_list}")
+            # Insert them right after 'yt-dlp':
+            command[1:1] = extra_args_list
+            # Or place them at the end:
+            # command.extend(extra_args_list)
 
         # Apply cache settings based on config
         if no_cache_dir:
@@ -345,6 +356,15 @@ async def download_audio(url, audio_path):
             url
         ]
 
+        # If there are custom args, parse them into a list and extend the command
+        if extra_args_str:
+            extra_args_list = shlex.split(extra_args_str)
+            logger.info(f"Using custom yt-dlp arguments from config: {extra_args_list}")
+            # Insert them right after 'yt-dlp':
+            command[1:1] = extra_args_list
+            # Or place them at the end:
+            # command.extend(extra_args_list)
+
         # if use_cookies_file and os.path.exists(cookies_file):
         #     command.extend(["--cookies", cookies_file])
 
@@ -374,6 +394,15 @@ async def download_audio(url, audio_path):
             "--output", audio_path,
             url
         ]
+
+        # If there are custom args, parse them into a list and extend the command
+        if extra_args_str:
+            extra_args_list = shlex.split(extra_args_str)
+            logger.info(f"Using custom yt-dlp arguments from config: {extra_args_list}")
+            # Insert them right after 'yt-dlp':
+            command[1:1] = extra_args_list
+            # Or place them at the end:
+            # command.extend(extra_args_list)
 
         # if use_cookies_file and os.path.exists(cookies_file):
         #     command.extend(["--cookies", cookies_file])


### PR DESCRIPTION
- v0.1713 - Added customizable `yt-dlp` commands to `config.ini` under `custom_yt_dlp_args`
   - Leave the entry blank if you don't want any custom commands to be added.
   - Adding custom commands might help with some sites that have i.e. chunking problems during download, or if you need to tweak something, etc.