### PR TITLE
`v0.1714` - fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ If you just need to see the options and help, type:
 ```
 
 ## Changes
+- v0.1714 - **More fixes**
+   - Graceful passing of description fetching errors
+      => (`yt-dlp` pushes onward w/ warnings if the description fetch yielded errors)
+   - Default client behavior changed to suit YouTube better when using `yt-dlp` (Android client in custom arguments as default in `config.ini`)
+   - Added `[Delays]` section to `config.ini`
+      => Set up delays between description and video fetching to avoid snags; user configurable
 - v0.1713 - Added customizable `yt-dlp` commands to `config.ini` under `custom_yt_dlp_args`
    - Leave the entry blank if you don't want any custom commands to be added.
    - Adding custom commands might help with some sites that have i.e. chunking problems during download, or if you need to tweak something, etc.

--- a/config/config.ini
+++ b/config/config.ini
@@ -100,14 +100,21 @@ completionmessage = Transcription complete. Have a nice day! 😊\n\n<i>P.S. If 
 cooldown_seconds = 10
 max_requests_per_minute = 5
 
+[Delays]
+# Wait time in seconds between fetching video description and downloading the file
+descriptionfetchdelay = 5
+
 [YTDLPSettings]
 # (((=== Custom commands for yt-dlp when downloading video/audio ===)))
 # If the entry below is blank, no extra flags are appended to the yt-dlp command.
 # (leave blank like so if no extra commands aren't needed)
 # (Example below); can help with "chunk side exceeded" errors in some cases, i.e.:
 # custom_yt_dlp_args = --http-chunk-size 0
+# ~~~ android client ~~~
+# custom_yt_dlp_args = --extractor-args "youtube:player_client=android"
+# ~~~
 # Just leave the entry below blank if you have no idea what you're doing. :-)
-custom_yt_dlp_args = 
+custom_yt_dlp_args = --extractor-args "youtube:player_client=android"
 # (((=== Cookies ===)))
 # Use your own `cookies.txt` file (true/false)
 # this is sometimes required for sites that require login
@@ -116,7 +123,7 @@ custom_yt_dlp_args =
 use_cookies_file = false
 cookies_file = config/cookies.txt
 # use cookies from your browser (to bypass yt-dlp woes)
-use_browser_cookies = true
+use_browser_cookies = false
 # your browser type
 browser_type = firefox
 # your browser cookies profile location, leave blank to use default location

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@
 # openai-whisper transcriber-bot for Telegram
 
 # version of this program
-version_number = "0.1713"
+version_number = "0.1714"
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # https://github.com/FlyingFathead/whisper-transcriber-telegram-bot/
@@ -911,7 +911,7 @@ class TranscriberBot:
                                 await app.bot.send_message(
                                     chat_id=owner_id,
                                     text=(
-                                        "<b>👋🤖 Whisper Transcriber Bot is now online!</b>\n"
+                                        f"<b>👋🤖 Whisper Transcriber Bot (v{version_number}) is now online!</b>\n"
                                         f"\nStart time: {start_time_utc} (UTC)"
                                         f"\nLocal time: {start_time_local}"                                        
                                     ),


### PR DESCRIPTION
- v0.1714 - **More fixes**
   - Graceful passing of description fetching errors
      => (`yt-dlp` pushes onward w/ warnings if the description fetch yielded errors)
   - Default client behavior changed to suit YouTube better when using `yt-dlp` (Android client in custom `yt-dlp` arguments as default in `config.ini`)
   - Added `[Delays]` section to `config.ini`
      => Set up delays between description and video fetching to avoid snags; user configurable delay times
   - Version number now visible on startup hello (if enabled for bot owner[s])