### PR TITLE
`v0.1716` - per-domain arg configs for yt-dlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ If you just need to see the options and help, type:
 ```
 
 ## Changes
+- v0.1716 - **NEW: Configurable per-domain yt-dlp arguments**
+  - Added new `[YTDLPSettings]` config options:
+    - `use_special_commands_for_domains = true` (set to `true` to enable)
+    - `special_domain_commands = ...` (multiline string)  
+  - Lets you specify domain-specific yt-dlp arguments (e.g., `--http-chunk-size 0 --downloader native`) for problematic sites like Rumble, BitChute, Odysee, etc.
+  - (list can be expanded by the user in `config.ini` as needed)   
+  - This approach solves repeated “Separator not found” or TCP/SSL connection errors by applying fallback flags/headers strictly to domains known to need them—without affecting other sites or default performance.
+  - The bot automatically detects if the domain portion of the URL matches your `special_domain_commands` and injects those extra yt-dlp flags into the download process, eliminating chunking/SSL issues specific to that site.
 - v0.1715 - **Timestamped TXT Output & Startup Ping Logging**
    - Added new config option `send_timestamped_txt` under `[TranscriptionSettings]` in `config.ini`.
    - If `sendasfiles = true` and `send_timestamped_txt = true`, the bot now generates and sends an additional `*_timestamped.txt` file along with the standard `.txt`, `.srt`, and `.vtt` files.

--- a/config/config.ini
+++ b/config/config.ini
@@ -139,19 +139,28 @@ custom_cache_dir =
 # (((=== Video-only Sites ===)))
 # some media sites don't always work well with yt-dlp's audio download feature
 # for compatibility, it's recommended to enable the flag below (true)
-download_original_video_for_domains_active = true
+download_original_video_for_domains_active = false
 # list your sites below to download original videos from, comma separated.
 # Example:
 # download_original_video_domains = site1.com, site2.com, site3.com
 # In other words, these are the sites we use to download original videos from.
 # (i.e. rumble.com has been a site that's been widely reported as having broken downloads; 
 # hence the video-only download method for that site and others alike.)
-download_original_video_domains = rumble.com
+download_original_video_domains = example.com
 # Use worst video quality when having to download videos (true/false)
 # this is usually recommended, because we will only need the _audio_ for transcription.
 # adding a high-quality video will cause massive file size increases.
 # however, in some cases you might want to turn this off
 use_worst_video_quality = true
+# Domain specific special commands
+# (i.e. for sites that are not working well with `yt-dlp`)
+# Special commands list active (true/false)
+use_special_commands_for_domains = true
+# special domain commands, if activated
+special_domain_commands =
+    rumble.com | --http-chunk-size 0 --format worstaudio/worst --downloader native --add-header "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+    bitchute.com | --http-chunk-size 0 --format worstaudio/worst --downloader native --add-header "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+    odysee.com | --http-chunk-size 0 --format worstaudio/worst --downloader native --add-header "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
 
 [VideoDescriptionSettings]
 # Set to True to use only a snippet of the video description

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -133,6 +133,37 @@ class ConfigLoader:
             'domains': domain_list
         }
 
+    @classmethod
+    def get_special_domain_commands(cls):
+        """
+        Returns a dict of domain -> custom yt-dlp argument string,
+        parsed from 'special_domain_commands' in the [YTDLPSettings] section.
+        """
+        config = cls.get_config()
+
+        # Only parse them if usage is enabled
+        enabled = config.getboolean("YTDLPSettings", "use_special_commands_for_domains", fallback=False)
+        if not enabled:
+            return {}  # No special commands if disabled
+
+        raw = config.get("YTDLPSettings", "special_domain_commands", fallback="").strip()
+        if not raw:
+            return {}
+
+        commands = {}
+        for line in raw.splitlines():
+            line = line.strip()
+            # Skip empty lines or comment lines if you want
+            if not line or line.startswith("#"):
+                continue
+            if '|' not in line:
+                continue
+            domain, args = line.split('|', 1)
+            domain = domain.strip().lower()
+            args = args.strip()
+            commands[domain] = args
+        return commands
+
     # get the owner ID's and ping on startup if needed
     @classmethod
     def get_owner_ids(cls):

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@
 # openai-whisper transcriber-bot for Telegram
 
 # version of this program
-version_number = "0.1715"
+version_number = "0.1716"
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # https://github.com/FlyingFathead/whisper-transcriber-telegram-bot/


### PR DESCRIPTION
- v0.1716 - **NEW: Configurable per-domain yt-dlp arguments**
  - Added new `[YTDLPSettings]` config options:
    - `use_special_commands_for_domains = true` (set to `true` to enable)
    - `special_domain_commands = ...` (multiline string)  
  - Lets you specify domain-specific yt-dlp arguments (e.g., `--http-chunk-size 0 --downloader native`) for problematic sites like Rumble, BitChute, Odysee, etc.
  - (list can be expanded by the user in `config.ini` as needed) 
  - This approach solves repeated “Separator not found” or TCP/SSL connection errors by applying fallback flags/headers strictly to domains known to need them—without affecting other sites or default performance. 
  - Example snippet in `config.ini`:
    ```ini
    # YTDLPSettings
    use_special_commands_for_domains = true

    special_domain_commands =
        rumble.com | --http-chunk-size 0 --downloader native --add-header "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
        bitchute.com | --http-chunk-size 0 --format worstaudio/worst --downloader native
        odysee.com | --http-chunk-size 0 --downloader native
    ```
  - The bot automatically detects if the domain portion of the URL matches your `special_domain_commands` and injects those extra yt-dlp flags into the download process, eliminating chunking/SSL issues specific to that site.