### PR TITLE
README docker compose instructions + transcription path mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ Just grab the latest pre-built version with:
    ```bash
    docker pull ghcr.io/flyingfathead/whisper-transcriber-telegram-bot:latest
    ```
+
+There is a `docker-compose.example.yaml` file in the repo, you can use it to run the bot. Just make sure to replace the `TELEGRAM_BOT_TOKEN` with your actual bot token.
+
 ---
+
 #### Dockerfile Install Option 2: Build the Docker image yourself
 
 If there's something wrong with GHCR's prebuilt image, you can also build the Docker image yourself.

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -3,10 +3,11 @@ version: '3.4'
 services:
 
   whisper-transcriber-telegram-bot:
-    image: whisper-transcriber-telegram-bot
+    image: ghcr.io/flyingfathead/whisper-transcriber-telegram-bot
     container_name: whisper-transcriber-telegram-bot
     volumes:
       - ./config:/app/config
+      - ./transcriptions:/app/transcriptions
       - whisper_cache:/root/.cache/whisper
     environment:
       - TELEGRAM_BOT_TOKEN=


### PR DESCRIPTION
- mentions example docker compose file in the repo
- use more explicit docker image path (would otherwise default to Dockerhub)
- mount transcriptions directory to host for further processing